### PR TITLE
Allow for running tests when lib-cov is not present

### DIFF
--- a/test/business-time.js
+++ b/test/business-time.js
@@ -2,7 +2,13 @@ var chai = require('chai');
 var moment = require('moment');
 
 var assert = chai.assert;
-var time = require('./../lib-cov/business-time');
+try {
+  var time = require('./../lib-cov/business-time');
+} catch(e) {
+  if (e.code === 'MODULE_NOT_FOUND') {
+    var time = require('./../lib/business-time');
+  }
+}
 
 
 suite('BusinessTime', function() {


### PR DESCRIPTION
Hi. I was looking at your code with a view to contributing as I need something similar, except with UK holidays. However, cloning the repo from cold and running the tests throws an error by trying to require a .gitignore'd sub-directory.

Adding a try-catch to the require allows the lib-cov version to be run by default, but falls back to the basic implementation when this is not available.
